### PR TITLE
enhancing __call__, checks classes and builtin_checks

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -202,7 +202,6 @@ class Check(BaseCheck):
         self,
         check_obj: Union[pd.DataFrame, pd.Series],
         column: Optional[str] = None,
-        column_name: Optional[str] = None,
     ) -> CheckResult:
         # pylint: disable=too-many-branches
         """Validate pandas DataFrame or Series.
@@ -226,9 +225,8 @@ class Check(BaseCheck):
 
             ``failure_cases``: subset of the check_object that failed.
         """
-        breakpoint()
         backend = self.get_backend(check_obj)(self)
-        return backend(check_obj, column, column_name)
+        return backend(check_obj, column)
 
     @classmethod
     def equal_to(cls, value: Any, **kwargs) -> "Check":

--- a/pandera/backends/base/__init__.py
+++ b/pandera/backends/base/__init__.py
@@ -114,7 +114,7 @@ class BaseCheckBackend(ABC):
         """Initializes a check backend object."""
         ...
 
-    def __call__(self, check_obj, key=None, column_name=None):
+    def __call__(self, check_obj, key=None):
         raise NotImplementedError
 
     def query(self, check_obj):

--- a/pandera/backends/pyspark/base.py
+++ b/pandera/backends/pyspark/base.py
@@ -80,7 +80,7 @@ class PysparkSchemaBackend(BaseSchemaBackend):
             False.
         """
         breakpoint()
-        check_result = check(check_obj, *args, schema.name)
+        check_result = check(check_obj, *args)
         if not check_result.check_passed:
             if check_result.failure_cases is None:
                 # encode scalar False values explicitly

--- a/pandera/backends/pyspark/builtin_checks.py
+++ b/pandera/backends/pyspark/builtin_checks.py
@@ -217,14 +217,15 @@ def str_contains(
 @register_builtin_check(
     error="str_startswith('{string}')",
 )
-def str_startswith(data: DataFrame, string: str, column_name) -> DataFrame:
+def str_startswith(data: DataFrame, string: str, kwargs: dict) -> bool:
     """Ensure that all values start with a certain string.
 
     :param string: String all values should start with
     :param kwargs: key-word arguments passed into the `Check` initializer.
     """
     breakpoint()  # TODO: change to accept column and perform check on it
-    return data.withColumn(column_name, data[column_name].startswith(string))
+
+    return True  # data.withColumn(column_name, data[column_name].startswith(string))
 
 
 @register_builtin_check(

--- a/pandera/backends/pyspark/checks.py
+++ b/pandera/backends/pyspark/checks.py
@@ -1,7 +1,7 @@
 """Check backend for pyspark."""
 
 from functools import partial
-from typing import Dict, List, Optional, Union, cast
+from typing import Dict, List, Optional, Union, cast, Any
 
 from pyspark.sql import DataFrame
 from multimethod import overload, DispatchError
@@ -9,6 +9,7 @@ from multimethod import overload, DispatchError
 from pandera.backends.base import BaseCheckBackend
 from pandera.api.base.checks import CheckResult, GroupbyObject
 from pandera.api.checks import Check
+from pandera.backends.pyspark import builtin_checks
 from pandera.api.pyspark.types import (
     is_table,
     is_bool,
@@ -87,8 +88,7 @@ class PySparkCheckBackend(BaseCheckBackend):
     def preprocess(
         self,
         check_obj: DataFrame,  # type: ignore [valid-type]
-        key,
-        col_name,
+        key: str,
     ) -> DataFrame:
         return check_obj
 
@@ -125,10 +125,11 @@ class PySparkCheckBackend(BaseCheckBackend):
     def apply(self, check_obj: is_table):  # type: ignore [valid-type]
         breakpoint()
         return self.check_fn(check_obj)
+
     @overload  # type: ignore [no-redef]
-    def apply(self, check_obj: is_table, key, column_name):  # type: ignore [valid-type]
+    def apply(self, check_obj: DataFrame, key: str, kwargs: dict):  # type: ignore [valid-type]
         breakpoint()
-        return self.check._check_fn(check_obj, key, column_name)
+        return self.check._check_fn(check_obj, key, kwargs)
 
     # @overload
     # def postprocess(self, check_obj, check_output):
@@ -269,12 +270,13 @@ class PySparkCheckBackend(BaseCheckBackend):
         self,
         check_obj: DataFrame,
         key: Optional[str] = None,
-        column_name: Optional[str] = None
     ) -> CheckResult:
-        breakpoint()
-        check_obj = self.preprocess(check_obj, key, column_name)
+        check_obj = self.preprocess(check_obj, key)
         try:
-            check_output = self.apply(check_obj, key, column_name)
+            breakpoint()
+            d = self.check._check_kwargs
+            a = "hello"
+            check_output = self.apply(check_obj, key, d)
         except DispatchError as exc:
             if exc.__cause__ is not None:
                 raise exc.__cause__


### PR DESCRIPTION
I don’t think we need to add another arg column_name
```
 backend = self.get_backend(check_obj)(self)
        return backend(check_obj, column, column_name)
```
since column is already present there.

Moreover, this is in pandera/api/checks.py which will impact pandas and others functionality too.. So I reverted this code back for now…

 There’s a kwargs which we can leverage as follows:
```
@register_builtin_check(
    error="str_startswith('{string}')",
)
def str_startswith(data: DataFrame, string: str, kwargs: dict) -> bool:
    """Ensure that all values start with a certain string.

    :param string: String all values should start with
    :param kwargs: key-word arguments passed into the `Check` initializer.
    """
    breakpoint()  # TODO: change to accept column and perform check on it

    return True 
```
with this I can access both column and value to check

```
> /Users/Neeraj_Malhotra/qb_assets/os/forked/pandera/pandera/backends/pyspark/builtin_checks.py(226)str_startswith()
-> breakpoint()  # TODO: change to accept column and perform check on it
(Pdb) kwargs
{'string': 'B'}
(Pdb) string
'product'
(Pdb) data.show()
+-------+-----+
|product|price|
+-------+-----+
|  Bread|    9|
| Butter|   15|
+-------+-----+
```

Next we can do something like `return df.filter(condition).limit(1) == 1` as boolean value as check result.