### PR TITLE
support error accessor on pyspark dataframe

### DIFF
--- a/pandera/accessors/pyspark_sql_accessor.py
+++ b/pandera/accessors/pyspark_sql_accessor.py
@@ -1,7 +1,4 @@
-"""Custom accessor functionality for modin.
-
-Source code adapted from pyspark.pandas implementation:
-https://spark.apache.org/docs/3.2.0/api/python/reference/pyspark.pandas/api/pyspark.pandas.extensions.register_dataframe_accessor.html?highlight=register_dataframe_accessor#pyspark.pandas.extensions.register_dataframe_accessor
+"""Custom accessor functionality for PySpark.Sql.
 """
 
 import warnings
@@ -10,11 +7,13 @@ from typing import Optional, Union
 
 
 from pandera.api.pyspark.container import DataFrameSchema
+from pandera.api.pyspark.error_handler import ErrorHandler
 
 """Register pyspark accessor for pandera schema metadata."""
 
 
 Schemas = Union[DataFrameSchema]
+Errors = Union[ErrorHandler]
 
 
 # Todo Refactor to create a seperate module for panderaAccessor
@@ -25,6 +24,7 @@ class PanderaAccessor:
         """Initialize the pandera accessor."""
         self._pyspark_obj = pyspark_obj
         self._schema: Optional[Schemas] = None
+        self._errors: Optional[Errors] = None
 
     @staticmethod
     def check_schema_type(schema: Schemas):
@@ -41,6 +41,11 @@ class PanderaAccessor:
     def schema(self) -> Optional[Schemas]:
         """Access schema metadata."""
         return self._schema
+
+    @property
+    def error(self) -> Optional[Errors]:
+        """Access errors metadata"""
+        return self._errors
 
 
 class CachedAccessor:
@@ -111,7 +116,6 @@ def register_dataframe_accessor(name):
     return _register_accessor(name, DataFrame)
 
 
-
 class PanderaDataFrameAccessor(PanderaAccessor):
     """Pandera accessor for pyspark DataFrame."""
 
@@ -121,8 +125,6 @@ class PanderaDataFrameAccessor(PanderaAccessor):
             raise TypeError(
                 f"schema arg must be a DataFrameSchema, found {type(schema)}"
             )
-
-
 
 
 register_dataframe_accessor("pandera")(PanderaDataFrameAccessor)

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -119,13 +119,9 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
         error_dicts = {}
         if error_handler.collected_errors:  # TODO: list of all errors
             error_dicts = error_handler.summarize(schema=schema)
-            # raise SchemaErrors(
-            #     schema=schema,
-            #     schema_errors=error_handler.collected_errors,
-            #     data=check_obj,
-            # )
 
-        return error_dicts
+        check_obj.pandera.errors = error_dicts
+        return check_obj
 
     def run_schema_component_checks(
         self,

--- a/tests/pyspark/test_pyspark_error.py
+++ b/tests/pyspark/test_pyspark_error.py
@@ -87,7 +87,7 @@ def test_pyspark_schema_data_checks(spark):
         title="ProductSchema",
     )
 
-    data_fail = [("Bread", 5, ["Food"]), ('Cutter', 15, ["99"])]
+    data_fail = [("Bread", 5, ["Food"]), ("Cutter", 15, ["99"])]
 
     spark_schema = T.StructType(
         [
@@ -134,3 +134,25 @@ def test_pyspark_fields(spark):
     errors = pandera_schema.report_errors(check_obj=df_fail)
 
     print(errors)
+
+
+def test_pyspark_error_handler(spark, sample_spark_schema):
+    """
+    Test getting error dict from a pyspark DataFrameSchema object
+    """
+
+    pandera_schema = DataFrameSchema(
+        columns={
+            "product": Column("str", checks=pa.Check.str_startswith("B")),
+            "price": Column("int", checks=pa.Check.gt(5)),
+        },
+        name="product_schema",
+        description="schema for product info",
+        title="ProductSchema",
+    )
+
+    data_fail = [("Bread", 5), ("Cutter", 15)]
+    df_fail = spark_df(spark, data_fail, sample_spark_schema)
+
+    df_out = pandera_schema.report_errors(check_obj=df_fail)
+    assert df_out.pandera.errors != None


### PR DESCRIPTION
now errors will be accessible on dataframe as `df.pandera.errors`